### PR TITLE
Added backward-compatible option to return objects (closes #39)

### DIFF
--- a/src/__tests__/csv.ts
+++ b/src/__tests__/csv.ts
@@ -250,6 +250,27 @@ describe('CSV', () => {
       expect(obj[1]).toEqual(['d', 'e', 'f']);
       expect(obj[2]).toEqual(['g', 'h', 'i']);
     });
+    it('should #7', () => {
+      const obj = CSV.parse('a,b,c\nd,e,f\ng,h,i', { output: "tuples" });
+      expect(obj[0]).toEqual(['a', 'b', 'c']);
+      expect(obj[1]).toEqual(['d', 'e', 'f']);
+      expect(obj[2]).toEqual(['g', 'h', 'i']);
+    });
+    it('should #8', () => {
+      const obj = CSV.parse('a,b,c\n1,2,3\n4,5,6\n7,8,9', { output: "objects" });
+      expect(obj).toHaveLength(3);
+      expect(obj[0]).toMatchObject({ a: '1', b: '2', c: '3' });
+      expect(obj[1]).toMatchObject({ a: '4', b: '5', c: '6' });
+      expect(obj[2]).toMatchObject({ a: '7', b: '8', c: '9' });
+    });
+    it('should #9', () => {
+      const obj = CSV.parse('a,b,c', { output: "objects" });
+      expect(obj).toHaveLength(0);
+    });
+    it('should #10', () => {
+      const obj = CSV.parse('', { output: "objects" });
+      expect(obj).toHaveLength(0);
+    });
   });
 
   describe('parse+stringify', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,3 +13,8 @@ export type PristineInput =
 export type ReadCallback = (row: Value[]) => void;
 export type ReadAllCallback = (rows: Value[][]) => void;
 export type ForEachCallback = (row: Value[], index: number) => void;
+export type ParseOptions = {
+  comma: Comma;
+  quote: Quote;
+  output: 'objects' | 'tuples';
+}


### PR DESCRIPTION
Tests have been updated and are passing. I ran the benchmarking, too, but I wasn't sure if you wanted me to copy the output to the readme. It remains performant.